### PR TITLE
 ' 键 不上屏 二简字 + 二简词，而是 二简词 + 二简字

### DIFF
--- a/sbxlm/sbfm.schema.yaml
+++ b/sbxlm/sbfm.schema.yaml
@@ -234,9 +234,9 @@ sbfm_basic_bindings:
     - match: "[bpmfdtnlgkhjqxzcsrywv]{3}"
       accept: "Shift+space"
       send_sequence: "{Home}{Right}{space}{Home}{Right}{space}{space}"
-    - match: "[bpmfdtnlgkhjqxzcsrywv][a-z0-9][bpmfdtnlgkhjqxzcsrywv]{2}"
+    - match: "[bpmfdtnlgkhjqxzcsrywv]{2}[bpmfdtnlgkhjqxzcsrywv][a-z0-9]"
       accept: "Shift+space"
-      send_sequence: "{Home}{Right}{Right}{space}{Home}{Right}{space}{space}"
+      send_sequence: "{Home}{Right}{space}{Home}{Right}{space}{space}"
     - match: "([bpmfdtnlgkhjqxzcsrywv][a-z0-9]){2}[aeuio]{0,2}"
       accept: ";"
       send_sequence: "{Home}{Right}{Right}{space}{space}"
@@ -257,9 +257,9 @@ sbfm_extra_bindings:
     - match: "[bpmfdtnlgkhjqxzcsrywv]{2}[a-z]"
       accept: "'"
       send_sequence: "{Home}{Right}{space}{apostrophe}{space}"    
-    - match: "[bpmfdtnlgkhjqxzcsrywv][a-z0-9][bpmfdtnlgkhjqxzcsrywv][a-z]"
+    - match: "[bpmfdtnlgkhjqxzcsrywv][a-z][bpmfdtnlgkhjqxzcsrywv][a-z0-9]"
       accept: "'"
-      send_sequence: "{Home}{Right}{Right}{space}{apostrophe}{space}"
+      send_sequence: "{Home}{Right}{Right}{apostrophe}{space}{space}"
 
 key_binder:
   bindings:
@@ -285,3 +285,4 @@ menu:
     - "[bpmfdtnlgkhjqxzcsrywv][a-z][bpmfdtnlgkhjqxzcsrywv][a-zA-Z][aeuio]{2}"
     - "[bpmfdtnlgkhjqxzcsrywv][BPMFDTNLGKHJQXZCSRYWV][a-z]{2}[aeuio]{2}"
   select_comment_pattern: "^[a-z]{4,}|[bpmfdtnlgkhjqxzcsrywv][a-z][bpmfdtnlgkhjqxzcsrywvBPMFDTNLGKHJQXZCSRYWV][a-z][aeuioAEUIO]{0,2}|[bpmfdtnlgkhjqxzcsrywv][BPMFDTNLGKHJQXZCSRYWV][a-z]{2}[aeuio]{0, 2}|[bpmfdtnlgkhjqxzcsrywv][a-z][bpmfdtnlgkhjqxzcsrywv][a-zA-Z][aeuio]{0,2}$"
+


### PR DESCRIPTION
飞码的组合变换 逻辑问题。 Update sbfm.schema.yaml

1. 二简字 + 二简词 的 三字，不需要 ' 键上屏，
    因为 二简词 首码大写，即可将 前述 二简字 顶屏，所以 功能重复了 ' 键上屏 的 该功能，
    ' 键 理应用于 二简词 + 二简字 的 三字（交换顺序）。

同样的道理，

2. 二简字 + 一简双字 的 三字，也不需要 shift + _ 键上屏，
    因为 一简双字 首码大写，即可将 前述 二简字 顶屏，所以 功能重复了 shift + _ 键上屏 的 该功能，
    shift + _ 键 理应用于 一简双字 + 二简字 的 三字（交换顺序）

============举例============

比如 二简字 + 二简词：

    【先得到】= xn_dd' = xndd' = xnDd'  后 2 者都是 5 码
        那么 xndd' 规则没必要，大写足以
       ' 键 应用于 二简词 + 二简字 【得到先】

再比如 二简字 + 一简双字：

    【这个人】= zl_gr; = zlgr↑= zlGr;  后 2 者都是 5 码  
        那么 zlgr↑规则没必要，大写足以 
       shift+_ 键 应用于 一简双字 + 二简字【个人这】

<img width="1308" height="1248" alt="image" src="https://github.com/user-attachments/assets/7ea3cda9-d9fc-4af0-85c0-fdee15d36617" />

<img width="1290" height="1220" alt="image" src="https://github.com/user-attachments/assets/e3801c21-991e-467f-b2c6-b6dfaebf6956" />
